### PR TITLE
Divide SQL traffic across read and write

### DIFF
--- a/jest/cleanDatabase.js
+++ b/jest/cleanDatabase.js
@@ -1,4 +1,4 @@
-const sql = require('../sql');
+const sql = require('../sql').write;
 
 const statements = [
   'DROP TABLE IF EXISTS answer',

--- a/jest/common.js
+++ b/jest/common.js
@@ -2,7 +2,7 @@ const express = require('express');
 const request = require('supertest');
 const { requestParser } = require('@atelier/util');
 const routes = require('../routes');
-const sql = require('../sql');
+const sql = require('../sql').read;
 
 const app = express();
 app.use(express.json());

--- a/routes/get.js
+++ b/routes/get.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { asyncTry } = require('@atelier/util');
-const sql = require('../sql');
+const sql = require('../sql').read;
 
 const router = express.Router();
 
@@ -56,7 +56,7 @@ const stmtGetQuestions = `
     ) AS answers
   FROM question
   LEFT JOIN answer
-    ON answer.question_id = question.question_id  
+    ON answer.question_id = question.question_id
   WHERE product_id = $1::INT
     AND question.reported = FALSE
     AND answer.reported IS DISTINCT FROM TRUE

--- a/routes/get.spec.js
+++ b/routes/get.spec.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const { app } = require('../jest/common');
-const sql = require('../sql');
+const sql = require('../sql').write;
 
 const ID = 100;
 

--- a/routes/get.spec.js
+++ b/routes/get.spec.js
@@ -4,7 +4,7 @@ const sql = require('../sql').write;
 
 const ID = 100;
 
-const sampleQuestion = () => ({
+const sampleQuestion = {
   product_id: ID,
   question_body: 'Body',
   question_date: new Date().toISOString(),
@@ -12,7 +12,7 @@ const sampleQuestion = () => ({
   asker_email: 'e@mail.com',
   question_helpfulness: 3,
   reported: false,
-});
+};
 
 async function sendQuestion(question) {
   const keys = Object.keys(question);
@@ -29,7 +29,7 @@ async function sendQuestion(question) {
   return received;
 }
 
-const sampleAnswer = () => ({
+const sampleAnswer = {
   question_id: ID,
   body: 'body',
   date: new Date().toISOString(),
@@ -38,7 +38,7 @@ const sampleAnswer = () => ({
   helpfulness: 3,
   reported: false,
   photos: 'a b c d',
-});
+};
 
 /** @returns {Promise<number>} */
 async function sendAnswer(answer) {
@@ -60,14 +60,10 @@ async function sendAnswer(answer) {
 }
 
 describe('GET /qa/questions/:question_id/answers', () => {
-  let sample;
-
-  beforeEach(() => { sample = sampleAnswer(); });
-
   it('sends results', async () => {
-    const { question_id } = await sendQuestion(sampleQuestion());
-    sample.question_id = question_id;
-    const received = await sendAnswer(sample);
+    const { question_id } = await sendQuestion(sampleQuestion);
+    const answer = { ...sampleAnswer, question_id };
+    const received = await sendAnswer(answer);
 
     const res = await request(app)
       .get(`/qa/questions/${question_id}/answers`)
@@ -78,9 +74,9 @@ describe('GET /qa/questions/:question_id/answers', () => {
   });
 
   it('sends an empty array with no results', async () => {
-    const { question_id } = await sendQuestion(sampleQuestion());
-    sample.question_id = question_id;
-    await sendAnswer(sample);
+    const { question_id } = await sendQuestion(sampleQuestion);
+    const answer = { ...sampleAnswer, question_id };
+    await sendAnswer(answer);
 
     const res = await request(app)
       .get(`/qa/questions/${question_id + 1}/answers`)
@@ -90,12 +86,11 @@ describe('GET /qa/questions/:question_id/answers', () => {
   });
 
   it('hides reported answers', async () => {
-    const { question_id } = await sendQuestion(sampleQuestion());
-    sample.question_id = question_id;
-    sample.reported = true;
-    await sendAnswer(sample);
-    sample.reported = false;
-    const received = await sendAnswer(sample);
+    const { question_id } = await sendQuestion(sampleQuestion);
+    const answer = { ...sampleAnswer, question_id, reported: true };
+    await sendAnswer(answer);
+    answer.reported = false;
+    const received = await sendAnswer(answer);
 
     const res = await request(app)
       .get(`/qa/questions/${question_id}/answers`)
@@ -105,29 +100,28 @@ describe('GET /qa/questions/:question_id/answers', () => {
   });
 
   it('splits photos appropriately', async () => {
-    const { question_id } = await sendQuestion(sampleQuestion());
-    sample.question_id = question_id;
-    await sendAnswer(sample);
-    sample.photos = '';
-    await sendAnswer(sample);
+    const { question_id } = await sendQuestion(sampleQuestion);
+    const answer = { ...sampleAnswer, question_id };
+    await sendAnswer(answer);
+    answer.photos = '';
+    await sendAnswer(answer);
 
     const res = await request(app)
       .get(`/qa/questions/${question_id}/answers`)
       .expect(200);
 
-    const photos = res.body.results
-      .map(answer => answer.photos);
+    const photos = res.body.results.map(answer => answer.photos);
 
     expect(photos).toEqual([['a', 'b', 'c', 'd'], []]);
   });
 
   it('paginates', async () => {
-    const { question_id } = await sendQuestion(sampleQuestion());
-    sample.question_id = question_id;
+    const { question_id } = await sendQuestion(sampleQuestion);
+    const answer = { ...sampleAnswer, question_id };
 
     for (let i = 1; i < 20; i += 1) {
-      sample.body = i.toString();
-      await sendAnswer(sample);
+      answer.body = i.toString();
+      await sendAnswer(answer);
     }
 
     const { body } = await request(app)
@@ -149,58 +143,54 @@ describe('GET /qa/questions/:question_id/answers', () => {
 });
 
 describe('GET /qa/questions', () => {
-  let sample;
-
-  beforeEach(() => { sample = sampleQuestion(); });
-
   it('sends results', async () => {
-    sample.product_id += 10;
-    const received = await sendQuestion(sample);
+    const question = { ...sampleQuestion, product_id: sampleQuestion.product_id + 10 };
+    const received = await sendQuestion(question);
 
     const res = await request(app)
-      .get(`/qa/questions?product_id=${sample.product_id}`)
+      .get(`/qa/questions?product_id=${question.product_id}`)
       .expect(200)
       .expect('Content-Type', /application\/json/i);
 
     expect(res.body).toEqual({
-      product_id: sample.product_id.toString(),
+      product_id: question.product_id.toString(),
       results: [received],
     });
   });
 
   it('sends an empty array with no results', async () => {
-    sample.product_id += 20;
-    await sendQuestion(sample);
+    const question = { ...sampleQuestion, product_id: sampleQuestion.product_id + 20 };
+    await sendQuestion(question);
 
     const res = await request(app)
-      .get(`/qa/questions?product_id=${sample.product_id + 30}`)
+      .get(`/qa/questions?product_id=${question.product_id + 30}`)
       .expect(200);
 
     expect(res.body.results).toEqual([]);
   });
 
   it('hides reported questions', async () => {
-    sample.product_id += 40;
-    const received = await sendQuestion(sample);
-    sample.reported = true;
-    await sendQuestion(sample);
+    const question = { ...sampleQuestion, product_id: sampleQuestion.product_id + 40 };
+    const received = await sendQuestion(question);
+    question.reported = true;
+    await sendQuestion(question);
 
     const res = await request(app)
-      .get(`/qa/questions?product_id=${sample.product_id}`)
+      .get(`/qa/questions?product_id=${question.product_id}`)
       .expect(200);
 
     expect(res.body.results).toEqual([received]);
   });
 
   it('paginates', async () => {
-    sample.product_id += 50;
+    const question = { ...sampleQuestion, product_id: sampleQuestion.product_id + 50 };
     for (let i = 1; i <= 20; i += 1) {
-      sample.question_body = i.toString();
-      await sendQuestion(sample);
+      question.question_body = i.toString();
+      await sendQuestion(question);
     }
 
     const { body } = await request(app)
-      .get(`/qa/questions?product_id=${sample.product_id}&count=3&page=4`)
+      .get(`/qa/questions?product_id=${question.product_id}&count=3&page=4`)
       .expect(200);
 
     const bodies = body.results.map(question => question.question_body);
@@ -209,16 +199,17 @@ describe('GET /qa/questions', () => {
   });
 
   it('displays only the corresponding answers', async () => {
-    const answer = sampleAnswer();
+    const question = { ...sampleQuestion };
+    const answer = { ...sampleAnswer };
     const answer_ids = [];
     for (let i = 0; i <= 5; i += 1) {
-      sample.product_id = ID + 60 + (i === 0 || i === 5 ? i : 3);
-      const { question_id } = await sendQuestion(sample);
+      question.product_id = ID + 60 + (i === 0 || i === 5 ? i : 3);
+      const { question_id } = await sendQuestion(question);
       answer.question_id = question_id;
       for (let j = 0; j <= 2; j += 1) {
         answer.reported = !j;
         const received = await sendAnswer(answer);
-        if (sample.product_id === ID + 43 && !answer.reported) {
+        if (question.product_id === ID + 43 && !answer.reported) {
           answer_ids.push(received.answer_id.toString());
         }
       }
@@ -235,17 +226,17 @@ describe('GET /qa/questions', () => {
   });
 
   it('splits photos appropriately', async () => {
-    const answer = sampleAnswer();
-    sample.product_id += 70;
-    const { question_id } = await sendQuestion(sample);
+    const question = { ...sampleQuestion, product_id: sampleQuestion.product_id + 70 };
+    const { question_id } = await sendQuestion(question);
 
+    const answer = { question_id, ...sampleAnswer };
     answer.question_id = question_id;
     await sendAnswer(answer);
     answer.photos = '';
     await sendAnswer(answer);
 
     const res = await request(app)
-      .get(`/qa/questions?product_id=${sample.product_id}`)
+      .get(`/qa/questions?product_id=${question.product_id}`)
       .expect(200);
 
     const photos = res.body.results

--- a/routes/post.js
+++ b/routes/post.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { asyncTry } = require('@atelier/util');
-const sql = require('../sql');
+const sql = require('../sql').write;
 
 const router = express.Router();
 

--- a/routes/post.spec.js
+++ b/routes/post.spec.js
@@ -1,23 +1,27 @@
 const request = require('supertest');
 const { app, getQuestion, getAnswer } = require('../jest/common');
 
+const sampleQuestion = {
+  product_id: 1,
+  body: '2',
+  name: '3',
+  email: '4@5.com',
+  reported: true, // make sure no illegal fields
+};
+
+const sampleAnswer = {
+  body: '2',
+  name: '3',
+  email: '4@5.com',
+  photos: ['a', 'b', 'c'],
+  reported: true, // make sure no illegal fields
+};
+
 describe('POST /qa/questions', () => {
-  let sampleRequest;
-
-  beforeEach(() => {
-    sampleRequest = {
-      product_id: 1,
-      body: '2',
-      name: '3',
-      email: '4@5.com',
-      reported: true, // make sure no illegal fields
-    };
-  });
-
   it('creates a question', async () => {
     const { text: question_id } = await request(app)
       .post('/qa/questions')
-      .send(sampleRequest)
+      .send(sampleQuestion)
       .expect(201);
 
     const created = await getQuestion(Number(question_id));
@@ -34,31 +38,19 @@ describe('POST /qa/questions', () => {
   });
 
   it('validates email', async () => {
-    sampleRequest.email = '45.com';
+    const question = { ...sampleQuestion, email: '45.com' };
     await request(app)
       .post('/qa/questions')
-      .send(sampleRequest)
+      .send(question)
       .expect(422);
   });
 });
 
 describe('POST /qa/questions/:question_id/answers', () => {
-  let sampleRequest;
-
-  beforeEach(() => {
-    sampleRequest = {
-      body: '2',
-      name: '3',
-      email: '4@5.com',
-      photos: ['a', 'b', 'c'],
-      reported: true, // make sure no illegal fields
-    };
-  });
-
   it('creates an answer', async () => {
     const { text: answer_id } = await request(app)
       .post('/qa/questions/1/answers')
-      .send(sampleRequest)
+      .send(sampleAnswer)
       .expect(201);
 
     const created = await getAnswer(Number(answer_id));
@@ -77,10 +69,10 @@ describe('POST /qa/questions/:question_id/answers', () => {
   });
 
   it('validates email', async () => {
-    sampleRequest.email = '45.com';
+    const answer = { ...sampleAnswer, email: '45.com' };
     await request(app)
       .post('/qa/questions/1/answers')
-      .send(sampleRequest)
+      .send(answer)
       .expect(422);
   });
 });

--- a/routes/put.js
+++ b/routes/put.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { tryPut } = require('@atelier/util');
-const sql = require('../sql');
+const sql = require('../sql').write;
 
 const router = express.Router();
 

--- a/sql.js
+++ b/sql.js
@@ -3,13 +3,19 @@ const { Client, Pool } = require('pg');
 const {
   DB_POOL,
   DB_URL,
+  DB_WRITE_URL,
 } = process.env;
 const max = Number(DB_POOL);
 
-const sql = max ? new Pool({
-  connectionString: DB_URL,
-  max,
-}) : new Client({ connectionString: DB_URL });
-sql.connect().catch(console.error);
+function getSql(connectionString) {
+  const sql = max
+    ? new Pool({ connectionString, max })
+    : new Client({ connectionString });
+  sql.connect().catch(console.error);
+  return sql;
+}
 
-module.exports = sql;
+const read = getSql(DB_URL);
+const write = DB_WRITE_URL ? getSql(DB_WRITE_URL) : read;
+
+module.exports = { read, write };


### PR DESCRIPTION
![postgres_highscore](https://user-images.githubusercontent.com/1874214/143538697-78e5bfa4-ea52-468d-85cd-cc2cabaa9e1f.png)

The idea here is to have one ["publisher" server](https://www.postgresql.org/docs/current/logical-replication-publication.html), which exclusively handles all database writes, and ["subscriber" servers](https://www.postgresql.org/docs/current/logical-replication-subscription.html) that can only perform read operations. Almost all database access for the Atelier API is read-only—SELECT statements are executed constantly, INSERTs and UPDATEs only rarely—so a single small server can handle the "publisher" role, leaving the "subscriber" role up to a [replicating](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html) fleet of servers connected by a [load balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html).

Using this method, the only limit on API performance is the budget required to spin up AWS instances for API servers and database servers. A few of each on the free tier were enough to handle 10,000 requests, the highest number of requests possible for a [loader.io](loader.io) test.